### PR TITLE
add validator framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+default:
+	GO111MODULE=on go build ./...
+
+test:
+	GO111MODULE=on go test ./...
+
+check:
+	GO111MODULE=off go get golang.org/x/lint/golint
+	GO111MODULE=on golint `go list ./...`

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tikv/client-validator
+
+go 1.12

--- a/validator/conf.go
+++ b/validator/conf.go
@@ -1,0 +1,104 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import "sync"
+
+var (
+	// LogTimeFormat defines the time format in checker/test execute log.
+	LogTimeFormat = "2006-01-02 15:04:05.999"
+	// LogFileLine indicates if output code position of caller in log.
+	LogFileLine = true
+)
+
+// FeatureStatus is the status of a feature.
+type FeatureStatus string
+
+// Feature status.
+const (
+	// The feature has passed checkers and all tests.
+	FeaturePass FeatureStatus = "PASS"
+	// The feature is not implemented.
+	FeatureNotImplemented FeatureStatus = "NOT_IMPL"
+	// The feature has incorrect behavior. (failed to pass checker)
+	FeatureFail FeatureStatus = "FAIL"
+	// The feature has passed the checker but failed in some tests. (may have bugs)
+	FeatureDefect FeatureStatus = "DEFECT"
+	// The feature is not tested. (prerequisite features not supported)
+	FeatureSkip FeatureStatus = "SKIP"
+)
+
+// Feature defines a feature. All features should be registered before main().
+func Feature(key, description string, requireFeatures []string, checkF func(ExecContext) FeatureStatus) string {
+	confMu.Lock()
+	defer confMu.Unlock()
+	for _, feature := range featureConfs {
+		if feature.key == key {
+			panic("duplicated feature key: " + key)
+		}
+	}
+	featureConfs = append(featureConfs, featureConf{
+		key:              key,
+		description:      description,
+		requiredFeatures: requireFeatures,
+		checkF:           checkF,
+	})
+	return key
+}
+
+// Story is a list of features. The features will be placed together in the test report.
+func Story(description string, features ...string) struct{} {
+	confMu.Lock()
+	defer confMu.Unlock()
+	storyConfs = append(storyConfs, storyConf{description: description, features: features})
+	return struct{}{}
+}
+
+// Test defines a test case. If testF panics, all features will be marked as
+// Defect. All tests should be registered before main().
+func Test(description string, features []string, testF func(ExecContext)) struct{} {
+	confMu.Lock()
+	defer confMu.Unlock()
+	testConfs = append(testConfs, testConf{
+		description: description,
+		features:    features,
+		testF:       testF,
+	})
+	return struct{}{}
+}
+
+type featureConf struct {
+	key              string
+	description      string
+	requiredFeatures []string
+	checkF           func(ExecContext) FeatureStatus
+}
+
+type storyConf struct {
+	description string
+	features    []string
+}
+
+type testConf struct {
+	description string
+	features    []string
+	testF       func(ExecContext)
+}
+
+var (
+	confMu       sync.RWMutex
+	featureConfs []featureConf
+	testConfs    []testConf
+	storyConfs   []storyConf
+)

--- a/validator/conf.go
+++ b/validator/conf.go
@@ -39,8 +39,8 @@ const (
 	FeatureSkip FeatureStatus = "SKIP"
 )
 
-// Feature defines a feature. All features should be registered before main().
-func Feature(key, description string, requireFeatures []string, checkF func(ExecContext) FeatureStatus) string {
+// RegisterFeature defines a feature. All features should be registered before main().
+func RegisterFeature(key, description string, requireFeatures []string, checkF func(ExecContext) FeatureStatus) string {
 	confMu.Lock()
 	defer confMu.Unlock()
 	for _, feature := range featureConfs {
@@ -57,17 +57,17 @@ func Feature(key, description string, requireFeatures []string, checkF func(Exec
 	return key
 }
 
-// Story is a list of features. The features will be placed together in the test report.
-func Story(description string, features ...string) struct{} {
+// RegisterStory is a list of features. The features will be placed together in the test report.
+func RegisterStory(description string, features ...string) struct{} {
 	confMu.Lock()
 	defer confMu.Unlock()
 	storyConfs = append(storyConfs, storyConf{description: description, features: features})
 	return struct{}{}
 }
 
-// Test defines a test case. If testF panics, all features will be marked as
+// RegisterTest defines a test case. If testF panics, all features will be marked as
 // Defect. All tests should be registered before main().
-func Test(description string, features []string, testF func(ExecContext)) struct{} {
+func RegisterTest(description string, features []string, testF func(ExecContext)) struct{} {
 	confMu.Lock()
 	defer confMu.Unlock()
 	testConfs = append(testConfs, testConf{

--- a/validator/context.go
+++ b/validator/context.go
@@ -1,0 +1,146 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// ExecContext contains methods need for checkF and testF.
+type ExecContext interface {
+	Log(format string, args ...interface{})
+
+	Fail(msg ...string)
+	Assert(b bool, msg ...string)
+	AssertNil(x interface{}, msg ...string)
+	AssertNotNil(x interface{}, msg ...string)
+	AssertEQ(x, y interface{}, msg ...string)
+	AssertNE(x, y interface{}, msg ...string)
+	AssertDeepEQ(x, y interface{}, msg ...string)
+	AddCallerDepth(n int)
+}
+
+// Recorder records a execute history of checker or test.
+type Recorder struct {
+	Description string   `json:"description,omitempty"`
+	Logs        []string `json:"logs,omitempty"`
+	Success     bool     `json:"success,omitempty"`
+}
+
+func newRecorder(description string) *Recorder {
+	return &Recorder{Description: description}
+}
+
+// Log records some message in the Recorder.
+func (r *Recorder) Log(format string, args ...interface{}) {
+	r.log(LogFileLine, format, args...)
+}
+
+func (r *Recorder) log(logCaller bool, format string, args ...interface{}) {
+	var builder strings.Builder
+	builder.WriteString(time.Now().Format(LogTimeFormat))
+	if logCaller {
+		builder.WriteByte(' ')
+		builder.WriteString(caller(3))
+	}
+	builder.WriteByte(' ')
+	builder.WriteString(fmt.Sprintf(format, args...))
+	r.Logs = append(r.Logs, builder.String())
+}
+
+// copy returns a copy that is safe to append logs.
+func (r *Recorder) copy() *Recorder {
+	return &Recorder{
+		Description: r.Description,
+		Logs:        r.Logs[:len(r.Logs):len(r.Logs)],
+		Success:     r.Success,
+	}
+}
+
+type asserter struct {
+	callerDepth int
+}
+
+func (a *asserter) Fail(msg ...string) {
+	a.panicNow("test is marked failed", msg...)
+}
+
+func (a *asserter) Assert(b bool, msg ...string) {
+	if !b {
+		a.panicNow("assertion failed", msg...)
+	}
+}
+
+func (a *asserter) AssertNil(x interface{}, msg ...string) {
+	if x != nil {
+		a.panicNow(fmt.Sprintf("expect nil, got %v", x), msg...)
+	}
+}
+
+func (a *asserter) AssertNotNil(x interface{}, msg ...string) {
+	if x == nil {
+		a.panicNow(fmt.Sprintf("expect not nil, got: %v", x), msg...)
+	}
+}
+
+func (a *asserter) AssertEQ(x, y interface{}, msg ...string) {
+	if x != y {
+		a.panicNow(fmt.Sprintf("expect equal, got %v and %v", x, y), msg...)
+	}
+}
+
+func (a *asserter) AssertNE(x, y interface{}, msg ...string) {
+	if x == y {
+		a.panicNow(fmt.Sprintf("expect not equal, got %v and %v", x, y), msg...)
+	}
+}
+
+func (a *asserter) AssertDeepEQ(x, y interface{}, msg ...string) {
+	if !reflect.DeepEqual(x, y) {
+		a.panicNow(fmt.Sprintf("expect equal, got %v and %v", x, y), msg...)
+	}
+}
+
+func (a *asserter) AddCallerDepth(n int) {
+	a.callerDepth += n
+}
+
+func (a *asserter) panicNow(msg string, userMessage ...string) {
+	var position string
+	if LogFileLine {
+		position = caller(3+a.callerDepth) + " "
+	}
+	if len(userMessage) > 0 {
+		panic(position + strings.Join(userMessage, ","))
+	}
+	panic(position + msg)
+}
+
+func caller(n int) string {
+	_, f, l, ok := runtime.Caller(n)
+	if ok {
+		return fmt.Sprintf("%s:%v", filepath.Base(f), l)
+	}
+	return ""
+}
+
+type execContext struct {
+	*Recorder
+	*asserter
+}

--- a/validator/report.go
+++ b/validator/report.go
@@ -1,0 +1,73 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+// FeatureReport is test report for a feature.
+type FeatureReport struct {
+	Key         string        `json:"key"`
+	Description string        `json:"description"`
+	Status      FeatureStatus `json:"status"`
+	Records     []Recorder    `json:"records"`
+}
+
+// StoryReport is the test report for a story.
+type StoryReport struct {
+	Description string          `json:"description,omitempty"`
+	Features    []FeatureReport `json:"features,omitempty"`
+}
+
+// Report contains test results.
+type Report struct {
+	Stories  []StoryReport   `json:"stories,omitempty"`
+	Features []FeatureReport `json:"features,omitempty"`
+}
+
+func (r *testRunner) report() Report {
+	var report Report
+	reported := make(map[string]struct{})
+	for _, s := range r.stories {
+		report.Stories = append(report.Stories, r.reportStory(s))
+		for _, k := range s.features {
+			reported[k] = struct{}{}
+		}
+	}
+	for _, f := range r.features {
+		if _, ok := reported[f.conf.key]; !ok {
+			report.Features = append(report.Features, r.reportFeature(f.conf.key))
+		}
+	}
+	return report
+}
+
+func (r *testRunner) reportStory(conf storyConf) StoryReport {
+	report := StoryReport{Description: conf.description}
+	for _, f := range conf.features {
+		report.Features = append(report.Features, r.reportFeature(f))
+	}
+	return report
+}
+
+func (r *testRunner) reportFeature(key string) FeatureReport {
+	f := r.featuresMap[key]
+	if f == nil {
+		panic("feature not found: " + key)
+	}
+
+	return FeatureReport{
+		Key:         f.conf.key,
+		Description: f.conf.description,
+		Status:      f.status,
+		Records:     f.records,
+	}
+}

--- a/validator/runner.go
+++ b/validator/runner.go
@@ -1,0 +1,142 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import "fmt"
+
+// RunAll runs all registered checkers and tests then determine status of
+// features.
+func RunAll() Report {
+	runner := newTestRunner()
+	runner.run()
+	return runner.report()
+}
+
+type featureInfo struct {
+	conf    featureConf
+	status  FeatureStatus
+	records []Recorder
+}
+
+type testRunner struct {
+	features    []*featureInfo
+	featuresMap map[string]*featureInfo
+	stories     []storyConf
+	tests       []testConf
+}
+
+func newTestRunner() *testRunner {
+	confMu.Lock()
+	defer confMu.Unlock()
+
+	runner := &testRunner{
+		featuresMap: make(map[string]*featureInfo),
+		stories:     append(storyConfs[:0:0], storyConfs...),
+		tests:       append(testConfs[:0:0], testConfs...),
+	}
+
+	for _, conf := range featureConfs {
+		f := &featureInfo{
+			conf:   conf,
+			status: FeatureSkip,
+		}
+		runner.features = append(runner.features, f)
+		runner.featuresMap[conf.key] = f
+	}
+	return runner
+}
+
+func (r *testRunner) run() {
+	for f := r.nextFeature(); f != nil; f = r.nextFeature() {
+		r.runFeatureChecker(f)
+	}
+	for _, t := range r.tests {
+		if r.checkRequiredFeatures(t.features) {
+			r.runTest(t)
+		}
+	}
+}
+
+func (r *testRunner) nextFeature() *featureInfo {
+	for _, f := range r.features {
+		if f.status == FeatureSkip && r.checkRequiredFeatures(f.conf.requiredFeatures) {
+			return f
+		}
+	}
+	return nil
+}
+
+func (r *testRunner) checkRequiredFeatures(features []string) bool {
+	for _, key := range features {
+		f, ok := r.featuresMap[key]
+		if !ok {
+			panic("required feature not found: " + key)
+		}
+		if f.status != FeaturePass && f.status != FeatureDefect {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *testRunner) runFeatureChecker(f *featureInfo) {
+	recorder := newRecorder(fmt.Sprintf("check %s(%s)", f.conf.key, f.conf.description))
+	f.status = r.callChecker(recorder, f.conf.checkF)
+	recorder.Log("check finish. success=%v, feature.status=%s", recorder.Success, f.status)
+	f.records = append(f.records, *recorder)
+}
+
+func (r *testRunner) callChecker(recorder *Recorder, f func(ExecContext) FeatureStatus) (status FeatureStatus) {
+	defer func() {
+		if err := recover(); err != nil {
+			recorder.log(false, "%v", err)
+			status = FeatureFail
+		}
+	}()
+
+	if f != nil {
+		status = f(execContext{Recorder: recorder, asserter: &asserter{}})
+		recorder.Success = (status == FeaturePass || status == FeatureNotImplemented)
+	} else {
+		status = FeatureSkip
+	}
+	return
+}
+
+func (r *testRunner) runTest(t testConf) {
+	recorder := newRecorder(t.description)
+	r.callTest(recorder, t.testF)
+	for _, key := range t.features {
+		f := r.featuresMap[key]
+		if !recorder.Success && f.status == FeaturePass {
+			f.status = FeatureDefect
+		}
+		recorder2 := recorder.copy()
+		recorder2.Log("test finish. success=%v, feature.status=%s", recorder2.Success, f.status)
+		f.records = append(f.records, *recorder2)
+	}
+}
+
+func (r *testRunner) callTest(recorder *Recorder, f func(ExecContext)) {
+	defer func() {
+		if err := recover(); err != nil {
+			recorder.log(false, "%v", err)
+		}
+	}()
+
+	if f != nil {
+		f(execContext{Recorder: recorder, asserter: &asserter{}})
+		recorder.Success = true // Success if not panic
+	}
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,0 +1,180 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/tikv/client-validator/validator"
+)
+
+var _ = validator.Feature("A", "describe A", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeaturePass
+})
+
+var _ = validator.Feature("B", "describe B", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeatureNotImplemented
+})
+
+var _ = validator.Feature("C", "describe C", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeatureFail
+})
+
+var _ = validator.Feature("D", "describe D", []string{"A"}, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeaturePass
+})
+
+var _ = validator.Feature("E", "describe E", []string{"A", "B"}, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeatureNotImplemented
+})
+
+var _ = validator.Feature("F", "describe F", []string{"A", "D"}, func(ctx validator.ExecContext) validator.FeatureStatus {
+	ctx.Log("foobar")
+	return validator.FeaturePass
+})
+
+var _ = validator.Story("E and F", "E", "F")
+
+var _ = validator.Feature("G", "describe G", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+	return validator.FeaturePass
+})
+
+var _ = validator.Test("test G", []string{"G"}, func(ctx validator.ExecContext) {
+	ctx.Fail("G has a bug")
+})
+
+func TestValidator(t *testing.T) {
+	validator.LogTimeFormat = "[TIME]"
+	validator.LogFileLine = false
+
+	expect := validator.Report{
+		Stories: []validator.StoryReport{
+			{
+				Description: "E and F",
+				Features: []validator.FeatureReport{
+					{
+						Key:         "E",
+						Description: "describe E",
+						Status:      validator.FeatureSkip,
+					},
+					{
+						Key:         "F",
+						Description: "describe F",
+						Status:      validator.FeaturePass,
+						Records: []validator.Recorder{
+							{
+								Description: "check F(describe F)",
+								Logs: []string{
+									"[TIME] foobar",
+									"[TIME] check finish. success=true, feature.status=PASS",
+								},
+								Success: true,
+							},
+						},
+					},
+				},
+			},
+		},
+		Features: []validator.FeatureReport{
+			{
+				Key:         "A",
+				Description: "describe A",
+				Status:      validator.FeaturePass,
+				Records: []validator.Recorder{
+					{
+						Description: "check A(describe A)",
+						Logs: []string{
+							"[TIME] check finish. success=true, feature.status=PASS",
+						},
+						Success: true,
+					},
+				},
+			},
+			{
+				Key:         "B",
+				Description: "describe B",
+				Status:      validator.FeatureNotImplemented,
+				Records: []validator.Recorder{
+					{
+						Description: "check B(describe B)",
+						Logs: []string{
+							"[TIME] check finish. success=true, feature.status=NOT_IMPL",
+						},
+						Success: true,
+					},
+				},
+			},
+			{
+				Key:         "C",
+				Description: "describe C",
+				Status:      validator.FeatureFail,
+				Records: []validator.Recorder{
+					{
+						Description: "check C(describe C)",
+						Logs: []string{
+							"[TIME] check finish. success=false, feature.status=FAIL",
+						},
+						Success: false,
+					},
+				},
+			},
+			{
+				Key:         "D",
+				Description: "describe D",
+				Status:      validator.FeaturePass,
+				Records: []validator.Recorder{
+					{
+						Description: "check D(describe D)",
+						Logs: []string{
+							"[TIME] check finish. success=true, feature.status=PASS",
+						},
+						Success: true,
+					},
+				},
+			},
+			{
+				Key:         "G",
+				Description: "describe G",
+				Status:      validator.FeatureDefect,
+				Records: []validator.Recorder{
+					{
+						Description: "check G(describe G)",
+						Logs: []string{
+							"[TIME] check finish. success=true, feature.status=PASS",
+						},
+						Success: true,
+					},
+					{
+						Description: "test G",
+						Logs: []string{
+							"[TIME] G has a bug",
+							"[TIME] test finish. success=false, feature.status=DEFECT",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectJson, _ := json.Marshal(expect)
+	reportJson, _ := json.Marshal(validator.RunAll())
+
+	if !bytes.Equal(expectJson, reportJson) {
+		t.Logf("expect: %s", expectJson)
+		t.Logf("got   : %s", reportJson)
+		t.FailNow()
+	}
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -21,38 +21,38 @@ import (
 	"github.com/tikv/client-validator/validator"
 )
 
-var _ = validator.Feature("A", "describe A", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("A", "describe A", nil, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeaturePass
 })
 
-var _ = validator.Feature("B", "describe B", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("B", "describe B", nil, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeatureNotImplemented
 })
 
-var _ = validator.Feature("C", "describe C", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("C", "describe C", nil, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeatureFail
 })
 
-var _ = validator.Feature("D", "describe D", []string{"A"}, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("D", "describe D", []string{"A"}, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeaturePass
 })
 
-var _ = validator.Feature("E", "describe E", []string{"A", "B"}, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("E", "describe E", []string{"A", "B"}, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeatureNotImplemented
 })
 
-var _ = validator.Feature("F", "describe F", []string{"A", "D"}, func(ctx validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("F", "describe F", []string{"A", "D"}, func(ctx validator.ExecContext) validator.FeatureStatus {
 	ctx.Log("foobar")
 	return validator.FeaturePass
 })
 
-var _ = validator.Story("E and F", "E", "F")
+var _ = validator.RegisterStory("E and F", "E", "F")
 
-var _ = validator.Feature("G", "describe G", nil, func(_ validator.ExecContext) validator.FeatureStatus {
+var _ = validator.RegisterFeature("G", "describe G", nil, func(_ validator.ExecContext) validator.FeatureStatus {
 	return validator.FeaturePass
 })
 
-var _ = validator.Test("test G", []string{"G"}, func(ctx validator.ExecContext) {
+var _ = validator.RegisterTest("test G", []string{"G"}, func(ctx validator.ExecContext) {
 	ctx.Fail("G has a bug")
 })
 


### PR DESCRIPTION
The basic usage is use `Feature()` and `Test()` to register features (iterms need to be checked) and tests (the logic of validation). Then call `RunAll()` to get the validator report.

`validator/validator_test.go` shows the general idea. A complete example of use can be viewed on my temporary branch: https://github.com/disksing/tikv-client-validator/tree/v1

Signed-off-by: disksing <i@disksing.com>